### PR TITLE
Remove redundant check in new `starts_with` implementation

### DIFF
--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -86,12 +86,10 @@ impl UncasedStr {
     /// ```
     #[inline(always)]
     pub fn starts_with(&self, string: &str) -> bool {
-        self.len() >= string.len()
-            && self
-                .as_str()
-                .get(..string.len())
-                .map(|s| Self::new(s) == string)
-                .unwrap_or(false)
+        self.as_str()
+            .get(..string.len())
+            .map(|s| Self::new(s) == string)
+            .unwrap_or(false)
     }
 
     /// Converts a `Box<UncasedStr>` into an `Uncased` without copying or


### PR DESCRIPTION
I’ve always wanted to PR against a PR since I read that this is possible.